### PR TITLE
Fix: Remove bug on infinite rendering of the Footer.

### DIFF
--- a/components/core/Footer/Footer.tsx
+++ b/components/core/Footer/Footer.tsx
@@ -75,7 +75,7 @@ const [linkCategories, setLinkCategories] = useState([
       setLinkCategories(newLinkState);
 
     }
-  }, [isMobile, linkCategories])
+  }, [isMobile])
     return (
         <footer className="footer">
             <div className="footer__column-break">


### PR DESCRIPTION
The list/array of linkCategories is recreated on every rendering which triggers new rendering. This bug can be triggered while on mobile mode. The linkCategories are static data, so i implement this quick fix. I've found more bugs, but let's see how this one will be resolved.

King Regards
Gaja