### PR TITLE
Automation keeping presales fork in sync with dc-demostore-core

### DIFF
--- a/.github/workflows/sync-presales-downstream.yml
+++ b/.github/workflows/sync-presales-downstream.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  rebase-presales-downstream:
+    if: github.repository == 'amplience/dc-demostore-presales'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: git
+      run: |        
+        git --version
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
+        
+        git remote add upstream https://github.com/amplience/dc-demostore-core
+        git fetch
+        git fetch upstream
+        git checkout main        
+        git rebase upstream/main        
+        git status
+        git push


### PR DESCRIPTION
This automation should only run on the downstream fork of this codebase. Keeping the downstream fork (dc-demostore-presales) in-sync with changes to the parent (dc-demostore-core).

Making this change in the parent repo, prevents a merge conflict in the downstream fork by adding this file there.

This automation contains logic to prevent this pipeline step from running on the parent repo, or running on any other fork of this repo except dc-demostore-presales. This shouldn't pose a risk to other forks / consumers of this codebase.

This has been done manually in the past, and can be automated like this.